### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==1.7.1
+Django==1.8.*
 dj-database-url==0.3.0
 dj-static==0.0.6
 django-appconf==0.6
@@ -8,4 +8,3 @@ drf-nested-routers==0.9.0
 gunicorn==19.1.1
 six==1.8.0
 static3==0.5.1
-wsgiref==0.1.2


### PR DESCRIPTION
Removed wsgiref==0.1.2 and changed Django version. With Python3, the server will not start without these changes and installation errors are thrown.
